### PR TITLE
Mentorsubject improvements

### DIFF
--- a/node/src/gql/mutation/me/update-answer.ts
+++ b/node/src/gql/mutation/me/update-answer.ts
@@ -62,9 +62,7 @@ export const updateAnswer = {
         question: args.questionId,
       },
       {
-        $set: {
-          ...args.answer,
-        },
+        $set: args.answer,
       },
       {
         upsert: true,

--- a/node/src/gql/mutation/me/update-mentor.ts
+++ b/node/src/gql/mutation/me/update-mentor.ts
@@ -58,9 +58,7 @@ export const updateMentor = {
     const updated = await MentorModel.findByIdAndUpdate(
       mentorUpdate._id,
       {
-        $set: {
-          ...mentorUpdate,
-        },
+        $set: mentorUpdate,
       },
       {
         new: true,

--- a/node/src/gql/mutation/me/update-question.ts
+++ b/node/src/gql/mutation/me/update-question.ts
@@ -52,7 +52,7 @@ export const updateQuestion = {
     const { _id, props } = toUpdateProps<Question>(args.question);
     return await QuestionModel.findOneAndUpdate(
       { _id: _id },
-      { $set: { ...props } },
+      { $set: props },
       {
         new: true,
         upsert: true,

--- a/node/src/models/Subject.ts
+++ b/node/src/models/Subject.ts
@@ -7,7 +7,7 @@ The full terms of this copyright and license should always be found in the root 
 import mongoose, { Schema, Document, Model } from 'mongoose';
 import { Question as QuestionModel } from 'models';
 import { PaginatedResolveResult } from './PaginatedResolveResult';
-import { Question } from './Question';
+import { Question, QuestionType } from './Question';
 
 const mongoPaging = require('mongo-cursor-pagination');
 mongoPaging.config.COLLATION = { locale: 'en', strength: 2 };
@@ -96,14 +96,16 @@ export interface SubjectModel extends Model<Subject> {
   getQuestions(
     subject: string | Subject,
     topicId?: string,
-    mentorId?: string
+    mentorId?: string,
+    type?: QuestionType
   ): SubjectQuestion[];
 }
 
 SubjectSchema.statics.getQuestions = async function (
   s: string | Subject,
   topicId?: string,
-  mentorId?: string
+  mentorId?: string,
+  type?: QuestionType
 ) {
   const subject: Subject = typeof s === 'string' ? await this.findById(s) : s;
   if (!subject) {
@@ -114,7 +116,10 @@ SubjectSchema.statics.getQuestions = async function (
     sQuestions = sQuestions.filter((sq) => sq.topics.includes(topicId));
   }
   const questions = await QuestionModel.find({
-    _id: { $in: sQuestions.map((q) => q.question) },
+    ...{
+      _id: { $in: sQuestions.map((q) => q.question) },
+    },
+    ...(type ? { type } : {}),
   });
   if (mentorId !== undefined) {
     sQuestions = sQuestions.filter((sq) =>


### PR DESCRIPTION
aim with db queries is always to minimize: batch queries where possible, execute in parallel where possible, select only what you need, filter as much as possible in the db query (e.g. pass `type` as a criteria to the mongo select rather than get a result and then filter type)

Let me know if you want to go over the changes or any questions