### PR TITLE
incremental answer updates

### DIFF
--- a/node/src/gql/mutation/me/upload-task-delete.ts
+++ b/node/src/gql/mutation/me/upload-task-delete.ts
@@ -11,10 +11,12 @@ import {
   GraphQLID,
 } from 'graphql';
 import {
+  Answer as AnswerModel,
   Mentor as MentorModel,
   Question as QuestionModel,
   UploadTask as UploadTaskModel,
 } from 'models';
+import { Status } from 'models/Answer';
 import { Mentor } from 'models/Mentor';
 import { User, UserRole } from 'models/User';
 
@@ -54,6 +56,23 @@ export const uploadTaskDelete = {
       mentor: mentor._id,
       question: args.questionId,
     });
+
+    await AnswerModel.findOneAndUpdate(
+      {
+        mentor: mentor._id,
+        question: args.questionId,
+      },
+      {
+        $set: {
+          status: Status.COMPLETE,
+        },
+      },
+      {
+        // to be on the safe side, if there's no anwser for some reason, make this a no-op:
+        new: false,
+        upsert: false,
+      }
+    );
     return Boolean(task);
   },
 };

--- a/node/test/graphql/mutation/api/upload-answer.spec.ts
+++ b/node/test/graphql/mutation/api/upload-answer.spec.ts
@@ -155,12 +155,95 @@ describe('uploadAnswer', () => {
     expect(updatedAnswer).to.eql({
       transcript:
         "My name is Clint Anderson and I'm a Nuclear Electrician's Mate",
-      status: 'COMPLETE',
+      status: 'INCOMPLETE',
       media: [],
       question: {
         _id: '511111111111111111111112',
       },
     });
+  });
+
+  it('appends media', async () => {
+    let response = await request(app)
+      .post('/graphql')
+      .set('mentor-graphql-req', 'true')
+      .set('Authorization', `bearer ${process.env.API_SECRET}`)
+      .send({
+        query: answerMutation,
+        variables: {
+          mentorId: '5ffdf41a1ee2c62111111111',
+          questionId: '511111111111111111111112',
+          answer: {
+            transcript:
+              "My name is Clint Anderson and I'm a Nuclear Electrician's Mate",
+            media: [
+              {
+                type: 'video',
+                tag: 'web',
+                url: `${process.env.STATIC_URL_BASE}/video.mp4`,
+              },
+            ],
+          },
+        },
+      });
+    expect(response.status).to.equal(200);
+    expect(response.body.data.api.uploadAnswer).to.eql(true);
+    // send twice:
+    response = await request(app)
+      .post('/graphql')
+      .set('mentor-graphql-req', 'true')
+      .set('Authorization', `bearer ${process.env.API_SECRET}`)
+      .send({
+        query: answerMutation,
+        variables: {
+          mentorId: '5ffdf41a1ee2c62111111111',
+          questionId: '511111111111111111111112',
+          answer: {
+            transcript:
+              "My name is Clint Anderson and I'm a Nuclear Electrician's Mate",
+            media: [
+              {
+                type: 'video',
+                tag: 'web',
+                url: `${process.env.STATIC_URL_BASE}/video.mp4`,
+              },
+            ],
+          },
+        },
+      });
+    expect(response.status).to.equal(200);
+    expect(response.body.data.api.uploadAnswer).to.eql(true);
+    const r2 = await request(app)
+      .post('/graphql')
+      .send({
+        query: `query {
+          mentor(id: "5ffdf41a1ee2c62111111111") {
+            answers {
+              transcript
+              status
+              media {
+                type
+                tag
+                url
+              }
+              question {
+                _id
+              }
+            }
+          }
+      }`,
+      });
+    expect(r2.status).to.equal(200);
+    const updatedAnswer = r2.body.data.mentor.answers.find(
+      (a: any) => a.question._id === '511111111111111111111112'
+    );
+    expect(updatedAnswer.media).to.eql([
+      {
+        type: 'video',
+        tag: 'web',
+        url: `${process.env.STATIC_URL_BASE}/video.mp4`,
+      },
+    ]);
   });
 
   it('uploads video with transcript', async () => {
@@ -215,7 +298,7 @@ describe('uploadAnswer', () => {
     expect(updatedAnswer).to.eql({
       transcript:
         "My name is Clint Anderson and I'm a Nuclear Electrician's Mate",
-      status: 'COMPLETE',
+      status: 'INCOMPLETE',
       media: [
         {
           type: 'video',


### PR DESCRIPTION
With the new queue uploader tasks run independently and need to update answer incrementally,
meaning transcribe will append its transcript, transcode will append its video files...

Another consequence is that upload answer cannot say when they all finish and mark the answer as "COMPLETE", that's now done when task is deleted.