### PR TITLE
recursively attempt to convert strings to object ids

### DIFF
--- a/node/src/gql/query/find-all.ts
+++ b/node/src/gql/query/find-all.ts
@@ -19,23 +19,21 @@ function convertStringsToObjectIds(filter: any) {
   if (!filter) {
     return filter;
   }
-  const keys = Object.keys(filter);
-  for (let i = 0; i < keys.length; i++) {
-    const key = keys[i];
-    const value = filter[key];
-    if (Array.isArray(value)) {
-      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-      for (let i = 0; i < value.length; i++) {
-        filter[key] = convertStringsToObjectIds(value);
-      }
-    } else if (typeof value === 'object') {
-      console.log('is object', value);
-      filter[key] = convertStringsToObjectIds(value);
-    } else if (typeof value === 'string') {
-      console.log('is string', value);
-      try {
-        filter[key] = mongoose.Types.ObjectId(value);
-      } catch (err) {}
+  if (typeof filter === 'string') {
+    try {
+      return mongoose.Types.ObjectId(filter);
+    } catch (err) {
+      return filter;
+    }
+  } else if (Array.isArray(filter)) {
+    for (let i = 0; i < filter.length; i++) {
+      const value2 = filter[i];
+      filter[i] = convertStringsToObjectIds(value2);
+    }
+  } else if (typeof filter === 'object') {
+    const keys = Object.keys(filter);
+    for (let i = 0; i < keys.length; i++) {
+      filter[keys[i]] = convertStringsToObjectIds(filter[keys[i]]);
     }
   }
   return filter;
@@ -68,7 +66,6 @@ export function findAll<T extends PaginatedResolveResult>(config: {
           next = cursor;
         }
       }
-
       if (Object.keys(filter).length > 0) {
         filter = {
           $and: [filter, { $or: [{ deleted: false }, { deleted: null }] }],

--- a/node/test/fixtures/mongodb/data-default.js
+++ b/node/test/fixtures/mongodb/data-default.js
@@ -401,7 +401,7 @@ module.exports = {
     {
       _id: ObjectId('5ffdf41a1ee2c62320b49ee3'),
       mentor: ObjectId('5ffdf41a1ee2c62111111111'),
-      classifierAnswer: ObjectId('511111111111111111111115'),
+      classifierAnswer: ObjectId('511111111111111111111174'),
       classifierAnswerType: 'OFF_TOPIC',
       question: 'who are you?',
       feedback: 'NEUTRAL',

--- a/node/test/graphql/query/userQuestions.spec.ts
+++ b/node/test/graphql/query/userQuestions.spec.ts
@@ -160,4 +160,76 @@ describe('userQuestions', () => {
       },
     });
   });
+
+  it('can filter userQuestions using operators', async () => {
+    const response = await request(app)
+      .post('/graphql')
+      .send({
+        query: `
+        query UserQuestions($filter: Object!, $limit: Int!, $cursor: String!, $sortBy: String!, $sortAscending: Boolean!){
+          userQuestions(filter: $filter, limit: $limit,cursor: $cursor,sortBy: $sortBy,sortAscending: $sortAscending){
+             edges {
+                    cursor
+                    node {
+                      classifierAnswer {
+                        _id
+                        transcript
+                        question {
+                          _id
+                          question
+                        }
+                      }
+                      graderAnswer {
+                        _id
+                        transcript
+                        question {
+                          _id
+                          question
+                        }
+                      }
+                    }
+                  }
+                  pageInfo {
+                    startCursor
+                    endCursor
+                    hasPreviousPage
+                    hasNextPage
+                  }
+          }
+        }
+      `,
+        variables: {
+          filter: {
+            classifierAnswer: {
+              $nin: ['511111111111111111111174'],
+            },
+          },
+          limit: 20,
+          cursor: '',
+          sortBy: 'createdAt',
+          sortAscending: false,
+        },
+      });
+    expect(response.status).to.equal(200);
+    expect(response.body.data.userQuestions.edges).to.eql([
+      {
+        cursor: 'W251bGwsIjVmZmRmNDFhMWVlMmM2MjMyMGI0OWVlMiJd',
+        node: { classifierAnswer: null, graderAnswer: null },
+      },
+      {
+        cursor: 'W251bGwsIjVmZmRmNDFhMWVlMmM2MjMyMGI0OWVlMSJd',
+        node: {
+          classifierAnswer: {
+            _id: '511111111111111111111112',
+            transcript: '[being still]',
+            question: {
+              _id: '511111111111111111111111',
+              question: "Don't talk and stay still.",
+            },
+          },
+          graderAnswer: null,
+        },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
An attempt is made to convert all query/mutations variables into object id's recursively.

Only variables that have valid object id formats are successfully converted.

I believe this _shouldn't_ cause any issues, because any string that is in the correct object id format (and is therefore converted into one) **should** be stored in mongo as an object id.